### PR TITLE
Fix: map view not properly centered after clicking markers

### DIFF
--- a/frontend/src/organisms/MapComponent.tsx
+++ b/frontend/src/organisms/MapComponent.tsx
@@ -1,7 +1,7 @@
 import { MapContainer, TileLayer, Marker, Popup, useMap } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 import { useState, useEffect } from "react";
-import L from "leaflet";
+import L, { point, map } from "leaflet";
 
 import { useCitiesStore } from "../store/citiesStore";
 import { useInterestPointsStore } from "../store/interestPointsStore";
@@ -40,6 +40,29 @@ export default function MapComponent({
 		});
 	}
 
+	// Useful code snippet (updated to use flyTo): https://stackoverflow.com/questions/65322670/change-center-position-of-react-leaflet-map
+	// About the flyTo() vs setView() methods: https://rstudio.github.io/leaflet/reference/map-methods.html
+
+	function FlyToInterestPoint() {
+		const map = useMap();
+		const { selectedInterestPoint } = useInterestPointsStore();
+
+		useEffect(() => {
+			if (selectedInterestPoint) {
+				map.flyTo(
+					[selectedInterestPoint.latitude, selectedInterestPoint.longitude],
+					//map.getZoom(),
+					10,
+					{
+						duration: 2,
+						animate: true,
+					},
+				);
+			}
+		}, [selectedInterestPoint, map]);
+
+		return null;
+	}
 	const [interestPoints, setInterestPoints] = useState<InterestPoint[]>([]);
 	const { selectedCity } = useCitiesStore();
 	const { interestPointsByCity, setSelectedInterestPoint } =
@@ -86,6 +109,7 @@ export default function MapComponent({
 			>
 				<TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
 				<FlyToCity coords={mapCenter} />
+				<FlyToInterestPoint />
 				{interestPoints.map((point) => (
 					<Marker
 						key={point.id}

--- a/frontend/src/organisms/MapComponent.tsx
+++ b/frontend/src/organisms/MapComponent.tsx
@@ -51,8 +51,7 @@ export default function MapComponent({
 			if (selectedInterestPoint) {
 				map.flyTo(
 					[selectedInterestPoint.latitude, selectedInterestPoint.longitude],
-					//map.getZoom(),
-					10,
+					map.getZoom(),
 					{
 						duration: 2,
 						animate: true,


### PR DESCRIPTION
- create function 'FlyToInterestPoint' to center map view
- use flytTo() method to smoothly move map view